### PR TITLE
Add missing `std` feature to allow to be used as dependency of `proc-macro`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,9 @@ edition = "2021"
 description = "Provides code to unescape string literals"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/rust-lang/literal-escaper"
+
+[dependencies]
+std = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-std' }
+
+[features]
+rustc-dep-of-std = ["dep:std"]


### PR DESCRIPTION
This allows to fix this error when building `proc-macro`:

```
error[E0463]: can't find crate for `std`
  |
  = note: the `x86_64-unknown-linux-gnu` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-linux-gnu`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`
```

r? @Urgau 