### PR TITLE
Update CHANGELOG and crate version to 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.2
+
+- Add new `rustc-dep-of-std` feature to allow building `libproc-macro`
+
 # 0.0.1
 
 - Add `EscapeError`, `MixedUnit` and `Mode` enums

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-literal-escaper"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Provides code to unescape string literals"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Needs https://github.com/rust-lang/literal-escaper/pull/4 to be merged first.

r? @Urgau 