### PR TITLE
Add an explicit dependency on rustc-std-workspace-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,15 @@ version = 4
 name = "rustc-literal-escaper"
 version = "0.0.2"
 dependencies = [
+ "rustc-std-workspace-core",
  "rustc-std-workspace-std",
 ]
+
+[[package]]
+name = "rustc-std-workspace-core"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "rustc-std-workspace-std"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/rust-lang/literal-escaper"
 
 [dependencies]
 std = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-std' }
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 
 [features]
-rustc-dep-of-std = ["dep:std"]
+rustc-dep-of-std = ["dep:std", "dep:core"]


### PR DESCRIPTION
When built as a proc-macro dependency with the `rustc-dep-of-std` feature, we add an explicit `std` dependency but not one on `core`. This means that any macros defined in `core` (such as panic-related macros) that refer to `::core::` will fail to compile when used in `literal-escaper`.

Work around this by adding an explicit dependency on `rustc-std-workspace-core` when the `rustc-dep-of-std` feature is enabled.