### PR TITLE
skip_whitespace: use a non-ref callback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,8 +344,8 @@ trait Unescape {
                         let _ = chars.next();
                         // skip whitespace for backslash newline, see [Rust language reference]
                         // (https://doc.rust-lang.org/reference/tokens.html#string-literals).
-                        let mut callback_err = |range, err| callback(range, Err(err));
-                        skip_ascii_whitespace(&mut chars, start, &mut callback_err);
+                        let callback_err = |range, err| callback(range, Err(err));
+                        skip_ascii_whitespace(&mut chars, start, callback_err);
                         continue;
                     } else {
                         Self::unescape_1(&mut chars)
@@ -444,7 +444,7 @@ fn unicode_escape(chars: &mut impl Iterator<Item = char>) -> Result<u32, EscapeE
 /// Skip ASCII whitespace, except for the formfeed character
 /// (see [this issue](https://github.com/rust-lang/rust/issues/136600)).
 /// Warns on unescaped newline and following non-ASCII whitespace.
-fn skip_ascii_whitespace<F>(chars: &mut Chars<'_>, start: usize, callback: &mut F)
+fn skip_ascii_whitespace<F>(chars: &mut Chars<'_>, start: usize, mut callback: F)
 where
     F: FnMut(Range<usize>, EscapeError),
 {


### PR DESCRIPTION
This simplifies code ever so slightly, but seems to optimize better with bench_skip_ascii_whitespace going from 13k ns to 12k ns for a ~7% perf win. This function is called by the unescape functions, but not the check functions, but none of the benchmarks for the unescape functions include whitespace escapes, so they should be just noise. Full results anyway:

| bench name | current | new | diff |
|-|-|-|-|
| bench_check_raw_byte_str_ascii | 44329.05 ns/iter (+/- 84.62) | 44563.79 ns/iter (+/- 73.15) | 0.5% |
| bench_check_raw_c_str_ascii | 41291.01 ns/iter (+/- 47.98) | 41074.82 ns/iter (+/- 55.79) | -0.5% |
| bench_check_raw_c_str_non_ascii | 52422.74 ns/iter (+/- 77.9) | 52528.6 ns/iter (+/- 43.03) | 0.2% |
| bench_check_raw_c_str_unicode | 174775.2 ns/iter (+/- 967.73) | 174510.83 ns/iter (+/- 754.32) | -0.2% |
| bench_check_raw_str_ascii | 41029.81 ns/iter (+/- 69.24) | 40801.5 ns/iter (+/- 148.06) | -0.6% |
| bench_check_raw_str_non_ascii | 52347.3 ns/iter (+/- 68.18) | 50534.07 ns/iter (+/- 77.04) | -3.5% |
| bench_check_raw_str_unicode | 171870.68 ns/iter (+/- 468.3) | 168191.82 ns/iter (+/- 487.05) | -2.1% |
| bench_skip_ascii_whitespace | 13069.39 ns/iter (+/- 10.35) | 12146.74 ns/iter (+/- 41.47) | -7.1% |
| bench_unescape_byte_str_ascii | 69227.9 ns/iter (+/- 115.92) | 68957.02 ns/iter (+/- 128.93) | -0.4% |
| bench_unescape_byte_str_ascii_escape | 85243.79 ns/iter (+/- 116.16) | 81618.08 ns/iter (+/- 154.13) | -4.3% |
| bench_unescape_byte_str_hex_escape | 125803.1 ns/iter (+/- 163.28) | 124808.68 ns/iter (+/- 184.41) | -0.8% |
| bench_unescape_byte_str_mixed_escape | 362076.7 ns/iter (+/- 1303.98) | 360177.25 ns/iter (+/- 1211.76) | -0.5% |
| bench_unescape_c_str_ascii | 84739.67 ns/iter (+/- 170.68) | 82777.93 ns/iter (+/- 130.72) | -2.3% |
| bench_unescape_c_str_ascii_escape | 97622.13 ns/iter (+/- 171.56) | 100090.55 ns/iter (+/- 762.39) | 2.5% |
| bench_unescape_c_str_hex_escape_ascii | 164471.32 ns/iter (+/- 342.05) | 166104.42 ns/iter (+/- 431.08) | 1.0% |
| bench_unescape_c_str_hex_escape_byte | 166290.54 ns/iter (+/- 276.57) | 165707.0 ns/iter (+/- 270.56) | -0.4% |
| bench_unescape_c_str_mixed_escape | 1061116.4 ns/iter (+/- 3354.17) | 1064596.3 ns/iter (+/- 3814.25) | 0.3% |
| bench_unescape_c_str_non_ascii | 110599.81 ns/iter (+/- 196.05) | 110626.81 ns/iter (+/- 269.57) | 0.0% |
| bench_unescape_c_str_unicode | 395626.4 ns/iter (+/- 1532.71) | 390032.55 ns/iter (+/- 1455.75) | -1.4% |
| bench_unescape_c_str_unicode_escape | 312402.87 ns/iter (+/- 1000.7) | 311308.72 ns/iter (+/- 1546.52) | -0.4% |
| bench_unescape_str_ascii | 71954.11 ns/iter (+/- 78.88) | 73341.17 ns/iter (+/- 149.8) | 1.9% |
| bench_unescape_str_ascii_escape | 105721.6 ns/iter (+/- 180.65) | 105908.94 ns/iter (+/- 156.22) | 0.2% |
| bench_unescape_str_hex_escape | 164854.82 ns/iter (+/- 216.09) | 164763.26 ns/iter (+/- 419.93) | -0.1% |
| bench_unescape_str_mixed_escape | 905346.95 ns/iter (+/- 1517.71) | 905614.95 ns/iter (+/- 3783.9) | 0.0% |
| bench_unescape_str_non_ascii | 98009.93 ns/iter (+/- 164.66) | 98224.14 ns/iter (+/- 82.23) | 0.2% |
| bench_unescape_str_unicode | 339978.93 ns/iter (+/- 618.14) | 343732.22 ns/iter (+/- 563.01) | 1.1% |
| bench_unescape_str_unicode_escape | 597426.3 ns/iter (+/- 6292.9) | 597124.2 ns/iter (+/- 6211.08) | -0.1% |

