### PR TITLE
Use NonZero in MixedUnit for C strings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,13 +11,13 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  stable-checks:
+  beta-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@beta
         with:
-          toolchain: stable
+          toolchain: beta
           components: rustfmt
       - run: cargo fmt -- --check
       - run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "Provides code to unescape string literals"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/rust-lang/literal-escaper"
+rust-version = "1.89" # for NonZero<char>
 
 [dependencies]
 std = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-std' }

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -3,6 +3,8 @@
 extern crate test;
 
 use rustc_literal_escaper::*;
+
+use std::num::NonZero;
 use std::ops::Range;
 use std::{array, iter};
 
@@ -58,7 +60,7 @@ macro_rules! fn_bench_check_raw {
 
 fn_bench_check_raw!(bench_check_raw_str, char, check_raw_str);
 fn_bench_check_raw!(bench_check_raw_byte_str, u8, check_raw_byte_str);
-fn_bench_check_raw!(bench_check_raw_c_str, char, check_raw_c_str);
+fn_bench_check_raw!(bench_check_raw_c_str, NonZero<char>, check_raw_c_str);
 
 // raw str
 
@@ -98,12 +100,12 @@ fn bench_check_raw_byte_str_ascii(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_check_raw_c_str_ascii(b: &mut test::Bencher) {
-    bench_check_raw_c_str(b, "a", &['a'; LEN]);
+    bench_check_raw_c_str(b, "a", &[NonZero::new('a').unwrap(); LEN]);
 }
 
 #[bench]
 fn bench_check_raw_c_str_non_ascii(b: &mut test::Bencher) {
-    bench_check_raw_c_str(b, "🦀", &['🦀'; LEN]);
+    bench_check_raw_c_str(b, "🦀", &[NonZero::new('🦀').unwrap(); LEN]);
 }
 
 #[bench]
@@ -111,12 +113,15 @@ fn bench_check_raw_c_str_unicode(b: &mut test::Bencher) {
     bench_check_raw_c_str(
         b,
         "a🦀🚀z",
-        &array::from_fn::<_, { 4 * LEN }, _>(|i| match i % 4 {
-            0 => 'a',
-            1 => '🦀',
-            2 => '🚀',
-            3 => 'z',
-            _ => unreachable!(),
+        &array::from_fn::<_, { 4 * LEN }, _>(|i| {
+            NonZero::new(match i % 4 {
+                0 => 'a',
+                1 => '🦀',
+                2 => '🚀',
+                3 => 'z',
+                _ => unreachable!(),
+            })
+            .unwrap()
         }),
     );
 }
@@ -318,7 +323,7 @@ fn bench_unescape_c_str_ascii(b: &mut test::Bencher) {
     bench_unescape_c_str(
         b,
         r"a",
-        &array::from_fn::<_, { LEN }, _>(|i| (i..i + 1, Ok(MixedUnit::Char('a')))),
+        &array::from_fn::<_, { LEN }, _>(|i| (i..i + 1, 'a'.try_into())),
     );
 }
 
@@ -327,7 +332,7 @@ fn bench_unescape_c_str_non_ascii(b: &mut test::Bencher) {
     bench_unescape_c_str(
         b,
         r"🦀",
-        &array::from_fn::<_, LEN, _>(|i| (4 * i..4 * (i + 1), Ok(MixedUnit::Char('🦀')))),
+        &array::from_fn::<_, LEN, _>(|i| (4 * i..4 * (i + 1), '🦀'.try_into())),
     );
 }
 
@@ -339,10 +344,10 @@ fn bench_unescape_c_str_unicode(b: &mut test::Bencher) {
         b,
         input,
         &array::from_fn::<_, { 4 * LEN }, _>(|i| match i % 4 {
-            0 => (i / 4 * l..i / 4 * l + 1, Ok(MixedUnit::Char('a'))),
-            1 => (i / 4 * l + 1..i / 4 * l + 5, Ok(MixedUnit::Char('🦀'))),
-            2 => (i / 4 * l + 5..i / 4 * l + 9, Ok(MixedUnit::Char('🚀'))),
-            3 => (i / 4 * l + 9..i / 4 * l + 10, Ok(MixedUnit::Char('z'))),
+            0 => (i / 4 * l..i / 4 * l + 1, 'a'.try_into()),
+            1 => (i / 4 * l + 1..i / 4 * l + 5, '🦀'.try_into()),
+            2 => (i / 4 * l + 5..i / 4 * l + 9, '🚀'.try_into()),
+            3 => (i / 4 * l + 9..i / 4 * l + 10, 'z'.try_into()),
             _ => unreachable!(),
         }),
     );
@@ -353,7 +358,7 @@ fn bench_unescape_c_str_ascii_escape(b: &mut test::Bencher) {
     bench_unescape_c_str(
         b,
         r"\n",
-        &array::from_fn::<_, { LEN }, _>(|i| (2 * i..2 * (i + 1), Ok(MixedUnit::Char('\n')))),
+        &array::from_fn::<_, { LEN }, _>(|i| (2 * i..2 * (i + 1), '\n'.try_into())),
     );
 }
 
@@ -362,7 +367,7 @@ fn bench_unescape_c_str_hex_escape_ascii(b: &mut test::Bencher) {
     bench_unescape_c_str(
         b,
         r"\x22",
-        &array::from_fn::<_, { LEN }, _>(|i| (4 * i..4 * (i + 1), Ok(MixedUnit::Char('"')))),
+        &array::from_fn::<_, { LEN }, _>(|i| (4 * i..4 * (i + 1), '"'.try_into())),
     );
 }
 
@@ -371,9 +376,7 @@ fn bench_unescape_c_str_hex_escape_byte(b: &mut test::Bencher) {
     bench_unescape_c_str(
         b,
         r"\xff",
-        &array::from_fn::<_, { LEN }, _>(|i| {
-            (4 * i..4 * (i + 1), Ok(MixedUnit::HighByte(b'\xff')))
-        }),
+        &array::from_fn::<_, { LEN }, _>(|i| (4 * i..4 * (i + 1), b'\xff'.try_into())),
     );
 }
 
@@ -382,7 +385,7 @@ fn bench_unescape_c_str_unicode_escape(b: &mut test::Bencher) {
     bench_unescape_c_str(
         b,
         r"\u{1f980}",
-        &array::from_fn::<_, { LEN }, _>(|i| (9 * i..9 * (i + 1), Ok(MixedUnit::Char('🦀')))),
+        &array::from_fn::<_, { LEN }, _>(|i| (9 * i..9 * (i + 1), '🦀'.try_into())),
     );
 }
 
@@ -399,14 +402,11 @@ fn bench_unescape_c_str_mixed_escape(b: &mut test::Bencher) {
             let mut i = 0;
             move || {
                 let res = Some(match i % n {
-                    0 => (i / n * l..i / n * l + 2, Ok(MixedUnit::Char('\n'))),
-                    1 => (i / n * l + 2..i / n * l + 6, Ok(MixedUnit::Char('"'))),
-                    2 => (i / n * l + 6..i / n * l + 15, Ok(MixedUnit::Char('🦀'))),
-                    3 => (i / n * l + 15..i / n * l + 24, Ok(MixedUnit::Char('🚀'))),
-                    4 => (
-                        i / n * l + 24..i / n * l + 28,
-                        Ok(MixedUnit::HighByte(b'\xff')),
-                    ),
+                    0 => (i / n * l..i / n * l + 2, '\n'.try_into()),
+                    1 => (i / n * l + 2..i / n * l + 6, '"'.try_into()),
+                    2 => (i / n * l + 6..i / n * l + 15, '🦀'.try_into()),
+                    3 => (i / n * l + 15..i / n * l + 24, '🚀'.try_into()),
+                    4 => (i / n * l + 24..i / n * l + 28, b'\xff'.try_into()),
                     r if r >= n => unreachable!(),
                     _ => unimplemented!(),
                 });


### PR DESCRIPTION
Make C strings safer, by encoding the absence of nulls in the type system. This is made possible by https://github.com/rust-lang/rust/pull/141001 which should hit stable in 1.89.

Performance seems largely unaffected. See details [for arm64](https://github.com/rust-lang/literal-escaper/pull/15#issuecomment-3004486202) and [for amd64](https://github.com/rust-lang/literal-escaper/pull/15#issuecomment-3004532601).