### PR TITLE
No-std

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
+          targets: x86_64-unknown-none
           components: rustfmt
       - run: cargo fmt -- --check
+      - run: cargo check
+      - run: cargo check --target=x86_64-unknown-none
       - run: cargo test
       # Ensure that no untracked or tracked files have been added or modified.
       - run: git diff --check --exit-code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
 //! Utilities for validating (raw) string, char, and byte literals and
 //! turning escape sequences into the values they represent.
 
-use std::ffi::CStr;
-use std::num::NonZero;
-use std::ops::Range;
-use std::str::Chars;
+#![no_std]
+
+use core::ffi::CStr;
+use core::num::NonZero;
+use core::ops::Range;
+use core::str::Chars;
 
 /// Errors and warnings that can occur during string, char, and byte unescaping.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,6 @@ use std::num::NonZero;
 use std::ops::Range;
 use std::str::Chars;
 
-#[cfg(test)]
-mod tests;
-
 /// Errors and warnings that can occur during string, char, and byte unescaping.
 ///
 /// Mostly relating to malformed escape sequences, but also a few other problems.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,8 @@
-use super::*;
+use rustc_literal_escaper::{
+    check_raw_byte_str, check_raw_str, unescape_byte, unescape_byte_str, unescape_char,
+    unescape_str, EscapeError,
+};
+use std::ops::Range;
 
 #[test]
 fn test_unescape_char_bad() {


### PR DESCRIPTION
This came up in the context of looking into no-std proc-macro2. Rust for Linux wants to be able to build quote and syn without giving them a std dependency.

For now proc-macro2 does not depend directly on rustc-literal-escaper (because of the requirement of extremely recent compiler version) but does contain a vendored copy of this code.