### PR TITLE
Remove dependency on rustc-std-workspace-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,6 @@ name = "rustc-literal-escaper"
 version = "0.0.6"
 dependencies = [
  "rustc-std-workspace-core",
- "rustc-std-workspace-std",
 ]
 
 [[package]]
@@ -15,9 +14,3 @@ name = "rustc-std-workspace-core"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
-
-[[package]]
-name = "rustc-std-workspace-std"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba676a20abe46e5b0f1b0deae474aaaf31407e6c71147159890574599da04ef"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/rust-lang/literal-escaper"
 rust-version = "1.89" # for NonZero<char>
 
 [dependencies]
-std = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-std' }
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 
 [features]
-rustc-dep-of-std = ["dep:std", "dep:core"]
+rustc-dep-of-std = ["dep:core"]


### PR DESCRIPTION
This crate was recently made no_std.