### PR TITLE
Make `EscapeError` enum non-exhaustive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use core::str::Chars;
 ///
 /// Mostly relating to malformed escape sequences, but also a few other problems.
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EscapeError {
     /// Expected 1 char, but 0 were found.
     ZeroChars,


### PR DESCRIPTION
We're in the process of stabilizing the new proc-macro API (https://github.com/rust-lang/rust/pull/151973) making use of this crate. However the `EscapeError` enum is publicly reexported by `proc-macro` and it was suggested to make it non-exhaustive to allow to potentially add more variants in the future and I think it's a good idea.

cc @Urgau 