### PR TITLE
Change CheckRaw::check_raw to use faster loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,28 +129,16 @@ trait CheckRaw {
         src: &str,
         mut callback: impl FnMut(Range<usize>, Result<Self::RawUnit, EscapeError>),
     ) {
-        let mut chars = src.chars();
-        while let Some(c) = chars.next() {
-            let start = src.len() - chars.as_str().len() - c.len_utf8();
-            let res = match c {
-                '\r' => Err(EscapeError::BareCarriageReturnInRawString),
-                _ => Self::char2raw_unit(c),
-            };
-            let end = src.len() - chars.as_str().len();
-            callback(start..end, res);
-        }
-
-        // Unfortunately, it is a bit unclear whether the following equivalent code is slower or faster: bug 141855
-        // src.char_indices().for_each(|(pos, c)| {
-        //     callback(
-        //         pos..pos + c.len_utf8(),
-        //         if c == '\r' {
-        //             Err(EscapeError::BareCarriageReturnInRawString)
-        //         } else {
-        //             Self::char2raw_unit(c)
-        //         },
-        //     );
-        // });
+        src.char_indices().for_each(|(pos, c)| {
+            callback(
+                pos..pos + c.len_utf8(),
+                if c == '\r' {
+                    Err(EscapeError::BareCarriageReturnInRawString)
+                } else {
+                    Self::char2raw_unit(c)
+                },
+            );
+        });
     }
 }
 


### PR DESCRIPTION
The new code is now arguably a win. Consisting of a pretty nice win on x86_64 and a mixed bag on aarch64:
Bad news first (aarch64):

| bench name | current | new | diff |
|-|-|-|-|
| bench_check_raw_byte_str_ascii | 44975.54 ns/iter (+/- 122.04) | 45243.84 ns/iter (+/- 128.8) | 0.6% |
| bench_check_raw_c_str_ascii | 41347.02 ns/iter (+/- 100.9) | 42029.0 ns/iter (+/- 103.52) | 1.6% |
| bench_check_raw_c_str_non_ascii | 52456.11 ns/iter (+/- 143.32) | 50600.13 ns/iter (+/- 123.49) | -3.5% |
| bench_check_raw_c_str_unicode | 174709.35 ns/iter (+/- 994.28) | 172602.8 ns/iter (+/- 1132.97) | -1.2% |
| bench_check_raw_str_ascii | 40680.45 ns/iter (+/- 143.71) | 42674.59 ns/iter (+/- 61.81) | 4.9% |
| bench_check_raw_str_non_ascii | 52421.81 ns/iter (+/- 4004.43) | 48340.07 ns/iter (+/- 145.87) | -7.8% |
| bench_check_raw_str_unicode | 170853.94 ns/iter (+/- 7519.49) | 165409.99 ns/iter (+/- 3117.97) | -3.2% |
| bench_skip_ascii_whitespace | 12053.53 ns/iter (+/- 29.99) | 12044.4 ns/iter (+/- 33.74) | -0.1% |
| bench_unescape_byte_str_ascii | 70602.06 ns/iter (+/- 272.56) | 70427.94 ns/iter (+/- 298.11) | -0.2% |
| bench_unescape_byte_str_ascii_escape | 83104.52 ns/iter (+/- 591.36) | 83610.41 ns/iter (+/- 1216.79) | 0.6% |
| bench_unescape_byte_str_hex_escape | 125182.88 ns/iter (+/- 295.67) | 125263.99 ns/iter (+/- 1713.3) | 0.1% |
| bench_unescape_byte_str_mixed_escape | 352221.45 ns/iter (+/- 1749.34) | 346931.0 ns/iter (+/- 3466.96) | -1.5% |
| bench_unescape_c_str_ascii | 80967.82 ns/iter (+/- 209.09) | 80922.68 ns/iter (+/- 157.71) | -0.1% |
| bench_unescape_c_str_ascii_escape | 100624.14 ns/iter (+/- 226.11) | 96678.42 ns/iter (+/- 299.64) | -3.9% |
| bench_unescape_c_str_hex_escape_ascii | 152883.53 ns/iter (+/- 338.72) | 152910.22 ns/iter (+/- 633.77) | 0.0% |
| bench_unescape_c_str_hex_escape_byte | 152880.12 ns/iter (+/- 328.01) | 152920.07 ns/iter (+/- 552.98) | 0.0% |
| bench_unescape_c_str_mixed_escape | 995095.1 ns/iter (+/- 2082.73) | 991280.5 ns/iter (+/- 3670.27) | -0.4% |
| bench_unescape_c_str_non_ascii | 97226.2 ns/iter (+/- 480.0) | 98656.1 ns/iter (+/- 388.43) | 1.5% |
| bench_unescape_c_str_unicode | 358065.3 ns/iter (+/- 1180.97) | 357940.6 ns/iter (+/- 2200.68) | -0.0% |
| bench_unescape_c_str_unicode_escape | 293758.7 ns/iter (+/- 681.95) | 293899.0 ns/iter (+/- 1333.28) | 0.0% |
| bench_unescape_str_ascii | 71426.26 ns/iter (+/- 185.89) | 71415.27 ns/iter (+/- 190.2) | -0.0% |
| bench_unescape_str_ascii_escape | 101579.7 ns/iter (+/- 1213.35) | 101623.52 ns/iter (+/- 998.66) | 0.0% |
| bench_unescape_str_hex_escape | 165016.6 ns/iter (+/- 633.74) | 165024.02 ns/iter (+/- 755.29) | 0.0% |
| bench_unescape_str_mixed_escape | 873936.8 ns/iter (+/- 3122.74) | 873456.35 ns/iter (+/- 3307.17) | -0.1% |
| bench_unescape_str_non_ascii | 101547.2 ns/iter (+/- 285.02) | 101565.63 ns/iter (+/- 405.17) | 0.0% |
| bench_unescape_str_unicode | 347195.22 ns/iter (+/- 1465.71) | 347676.25 ns/iter (+/- 1490.81) | 0.1% |
| bench_unescape_str_unicode_escape | 567043.1 ns/iter (+/- 3882.75) | 566738.7 ns/iter (+/- 4491.72) | -0.1% |

Good news (amd64):
| bench name | current | new | diff |
|-|-|-|-|
| bench_check_raw_byte_str_ascii | 14673.49 ns/iter (+/- 56.91) | 15427.88 ns/iter (+/- 233.4) | 5.1% |
| bench_check_raw_c_str_ascii | 17381.31 ns/iter (+/- 132.56) | 16034.73 ns/iter (+/- 42.92) | -7.7% |
| bench_check_raw_c_str_non_ascii | 28927.25 ns/iter (+/- 101.33) | 28935.69 ns/iter (+/- 195.69) | 0.0% |
| bench_check_raw_c_str_unicode | 96578.18 ns/iter (+/- 1024.94) | 90024.75 ns/iter (+/- 637.11) | -6.8% |
| bench_check_raw_str_ascii | 17347.19 ns/iter (+/- 124.5) | 14492.44 ns/iter (+/- 89.41) | -16.5% |
| bench_check_raw_str_non_ascii | 27939.65 ns/iter (+/- 188.23) | 28872.35 ns/iter (+/- 188.87) | 3.3% |
| bench_check_raw_str_unicode | 92351.89 ns/iter (+/- 734.69) | 86846.82 ns/iter (+/- 659.86) | -6.0% |
| bench_skip_ascii_whitespace | 5199.76 ns/iter (+/- 91.65) | 5298.54 ns/iter (+/- 49.68) | 1.9% |
| bench_unescape_byte_str_ascii | 37040.84 ns/iter (+/- 247.7) | 37090.81 ns/iter (+/- 198.68) | 0.1% |
| bench_unescape_byte_str_ascii_escape | 48589.68 ns/iter (+/- 428.52) | 45667.18 ns/iter (+/- 244.43) | -6.0% |
| bench_unescape_byte_str_hex_escape | 68835.06 ns/iter (+/- 377.27) | 66016.26 ns/iter (+/- 714.54) | -4.1% |
| bench_unescape_byte_str_mixed_escape | 199971.5 ns/iter (+/- 1396.65) | 187708.0 ns/iter (+/- 1612.42) | -6.1% |
| bench_unescape_c_str_ascii | 38973.3 ns/iter (+/- 116.68) | 36157.03 ns/iter (+/- 245.48) | -7.2% |
| bench_unescape_c_str_ascii_escape | 47616.33 ns/iter (+/- 172.06) | 47707.0 ns/iter (+/- 257.69) | 0.2% |
| bench_unescape_c_str_hex_escape_ascii | 73579.14 ns/iter (+/- 319.18) | 69254.71 ns/iter (+/- 601.56) | -5.9% |
| bench_unescape_c_str_hex_escape_byte | 73586.92 ns/iter (+/- 419.18) | 69298.14 ns/iter (+/- 504.8) | -5.8% |
| bench_unescape_c_str_mixed_escape | 446435.0 ns/iter (+/- 3489.35) | 435087.9 ns/iter (+/- 5463.8) | -2.5% |
| bench_unescape_c_str_non_ascii | 50545.5 ns/iter (+/- 438.33) | 50611.27 ns/iter (+/- 279.66) | 0.1% |
| bench_unescape_c_str_unicode | 179529.3 ns/iter (+/- 844.1) | 173854.35 ns/iter (+/- 1067.4) | -3.2% |
| bench_unescape_c_str_unicode_escape | 128361.36 ns/iter (+/- 616.2) | 125567.4 ns/iter (+/- 793.37) | -2.2% |
| bench_unescape_str_ascii | 37606.1 ns/iter (+/- 212.6) | 36979.03 ns/iter (+/- 230.71) | -1.7% |
| bench_unescape_str_ascii_escape | 54921.32 ns/iter (+/- 423.13) | 51389.84 ns/iter (+/- 387.13) | -6.4% |
| bench_unescape_str_hex_escape | 80971.95 ns/iter (+/- 947.78) | 83224.65 ns/iter (+/- 544.21) | 2.8% |
| bench_unescape_str_mixed_escape | 493874.9 ns/iter (+/- 3519.55) | 422836.5 ns/iter (+/- 3489.99) | -14.4% |
| bench_unescape_str_non_ascii | 54893.66 ns/iter (+/- 174.57) | 54444.72 ns/iter (+/- 482.78) | -0.8% |
| bench_unescape_str_unicode | 185288.78 ns/iter (+/- 1152.86) | 186621.78 ns/iter (+/- 2025.4) | 0.7% |
| bench_unescape_str_unicode_escape | 310795.63 ns/iter (+/- 5548.51) | 276933.0 ns/iter (+/- 1832.24) | -10.9% |
